### PR TITLE
Re-enable remote Pants cache; use Vault

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -1,12 +1,17 @@
 ---
+env:
+  PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
+  BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
+
 steps:
   - label: ":docker::cloudsmith: Build and Upload Docker Containers"
     command:
       - make image-push
     plugins:
-      - seek-oss/aws-sm#v2.3.1:
-          env:
-            CLOUDSMITH_API_KEY: "cloudsmith-token"
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - CLOUDSMITH_API_KEY
       - docker-login#v2.0.1:
           username: grapl-cicd
           password-env: CLOUDSMITH_API_KEY

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -1,10 +1,16 @@
 env:
   PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
+  BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
 
 steps:
   - label: ":lint-roller::bash: Lint Bash"
     command:
       - make lint-bash
+    plugins:
+      - grapl-security/vault-login#v0.1.0
+      - grapl-security/vault-env#v0.1.0:
+          secrets:
+            - codecov-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 
   - label: ":lint-roller::docker: Lint Dockerfile"
     command:

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -12,7 +12,5 @@ pants_ignore = [
   ".cache/pants/lmdb_store",
 ]
 
-# Temporarily disable the remote cache until we can get
-# repository-specific tokens into the CI/CD system
-# [auth]
-# from_env_var = "TOOLCHAIN_AUTH_TOKEN"
+[auth]
+from_env_var = "TOOLCHAIN_AUTH_TOKEN"


### PR DESCRIPTION
Now that Vault is available, we can access repository-specific cache
tokens.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>