### PR TITLE
Rename Makefile targets in terms of "shell", not "bash"

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -3,9 +3,9 @@ env:
   BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
 
 steps:
-  - label: ":lint-roller::bash: Lint Bash"
+  - label: ":lint-roller::bash: Lint Shell"
     command:
-      - make lint-bash
+      - make lint-shell
     plugins:
       - grapl-security/vault-login#v0.1.0
       - grapl-security/vault-env#v0.1.0:

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ COMPOSE_USER=$(shell id -u):$(shell id -g)
 ########################################################################
 
 .PHONY: lint
-lint: lint-plugin lint-bash lint-docker lint-hcl
+lint: lint-plugin lint-shell lint-docker lint-hcl
 
 .PHONY: lint-plugin
 lint-plugin:
 	docker-compose run --rm plugin-linter
 
-.PHONY: lint-bash
-lint-bash:
+.PHONY: lint-shell
+lint-shell:
 	./pants lint ::
 
 .PHONY: lint-docker
@@ -26,14 +26,14 @@ lint-hcl:
 ########################################################################
 
 .PHONY: format
-format: format-hcl format-bash
+format: format-hcl format-shell
 
 .PHONY: format-hcl
 format-hcl:
 	docker-compose run --rm --user=${COMPOSE_USER} hcl-formatter
 
-.PHONY: format-bash
-format-bash:
+.PHONY: format-shell
+format-shell:
 	./pants fmt ::
 
 # Testing


### PR DESCRIPTION
This is more general, and in keeping with the pattern across the rest
of our repositories.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>