### PR TITLE
Use docker queue instead of artifact-uploaders

### DIFF
--- a/.buildkite/pipeline.merge.build-container.yml
+++ b/.buildkite/pipeline.merge.build-container.yml
@@ -39,4 +39,4 @@ steps:
             packages:
               codecov: latest
     agents:
-      queue: "artifact-uploaders"
+      queue: "docker"


### PR DESCRIPTION
We recently retired the artifact-uploaders queue; this pipeline
slipped through the cracks because it's been a while since we ran the
merge pipeline.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
