### PR TITLE
Add a `fail_job_on_error` configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ steps:
 This can also be set this globally using the
 `BUILDKITE_PLUGIN_CODECOV_TAG` environment variable.
 
+By default, this plugin will fail a job if Codecov does not
+succesfully run. If you do not want to do this, use the
+`fail_job_on_error` parameter:
+
+```yml
+steps:
+  - command: make test
+    plugins:
+      - grapl-security/codecov#v0.1.0:
+          fail_job_on_error: false
+```
+
 ## Configuration
 
 ### `file` (optional, string)
@@ -85,6 +97,14 @@ Defaults to `docker.cloudsmith.io/grapl/releases/codecov`.
 The container image tag the plugin uses.
 
 Defaults to `latest`.
+
+### `fail_job_on_error` (optional, boolean)
+
+Whether or not an error in Codecov will fail the job. This can be
+useful for catching misconfigurations and errors in your Codecov
+setup, at the expense of failing jobs that would otherwise succeed.
+
+Defaults to `true`.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This can also be set this globally using the
 
 ## Configuration
 
-### file (optional, string)
+### `file` (optional, string)
 
 A file name or glob for the coverage files to upload to
 https://coverage.io. The value is passed as the `--file` argument to
@@ -72,7 +72,7 @@ the [Codecov Uploader][uploader].
 
 Defaults to `dist/coverage/**/*.xml`.
 
-### image (optional, string)
+### `image` (optional, string)
 
 The container image with the Codecov Uploader binary that the plugin
 uses. Any container used should have the `codecov` binary as its
@@ -80,7 +80,7 @@ entrypoint.
 
 Defaults to `docker.cloudsmith.io/grapl/releases/codecov`.
 
-### tag (optional, string)
+### `tag` (optional, string)
 
 The container image tag the plugin uses.
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -15,6 +15,14 @@ readonly default_tag="latest"
 readonly image="${BUILDKITE_PLUGIN_CODECOV_IMAGE:-${default_image}}:${BUILDKITE_PLUGIN_CODECOV_TAG:-${default_tag}}"
 readonly file_glob="${BUILDKITE_PLUGIN_CODECOV_FILE:-${default_file}}"
 
+readonly default_fail_job_on_error="true"
+
+codecov_args=(--verbose --file="${file_glob}" --rootDir=/workdir)
+
+if [ "${BUILDKITE_PLUGIN_CODECOV_FAIL_JOB_ON_ERROR:-${default_fail_job_on_error}}" = "true" ]; then
+    codecov_args+=(--nonZero)
+fi
+
 echo "--- :codecov: Uploading Coverage Reports"
 docker run \
     --init \
@@ -33,4 +41,4 @@ docker run \
     --env=BUILDKITE_JOB_ID \
     --env=BUILDKITE_PROJECT_SLUG \
     -- \
-    "${image}" --verbose --file="${file_glob}" --rootDir="/workdir"
+    "${image}" "${codecov_args[@]}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,4 +18,13 @@ configuration:
       description: |
         The `codecov` image tag to use; defaults to `latest`.
       type: string
+    fail_job_on_error:
+      description: |
+        Whether or not an error in Codecov will fail the job. This can
+        be useful for catching misconfigurations and errors in your
+        Codecov setup, at the expense of failing jobs that would
+        otherwise succeed.
+
+        Defaults to `true`.
+      type: boolean
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,12 +6,16 @@ requirements: ["docker"]
 configuration:
   properties:
     file:
-      description: The file(s) to upload; defaults to `dist/coverage/**/*.xml`
+      description: |
+        The file(s) to upload; defaults to `dist/coverage/**/*.xml`.
       type: string
     image:
-      description: The `codecov` image to use; defaults to `docker.cloudsmith.io/grapl/releases/codecov`
+      description: |
+        The `codecov` image to use; defaults to
+        `docker.cloudsmith.io/grapl/releases/codecov`
       type: string
     tag:
-      description: The `codecov` image tag to use; defaults to `latest`
+      description: |
+        The `codecov` image tag to use; defaults to `latest`.
       type: string
   additionalProperties: false

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -39,7 +39,7 @@ teardown() {
 
 @test "calls codecov with default values" {
   stub docker \
-       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml : echo 'uploading default files'"
+       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir : echo 'uploading default files'"
 
   run $PWD/hooks/post-command
 
@@ -52,7 +52,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_FILE="foo/bar.xml"
 
   stub docker \
-       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=foo/bar.xml : echo 'overriding default file glob'"
+       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=foo/bar.xml --rootDir=/workdir : echo 'overriding default file glob'"
 
   run $PWD/hooks/post-command
 
@@ -65,7 +65,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_IMAGE=foo/codecov
 
   stub docker \
-     "${docker_run_cmd} foo/codecov:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml : echo 'overrode the default image'"
+     "${docker_run_cmd} foo/codecov:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir : echo 'overrode the default image'"
 
   run $PWD/hooks/post-command
 
@@ -78,7 +78,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_TAG=v6.6.6
 
   stub docker \
-     "${docker_run_cmd} ${DEFAULT_IMAGE}:v6.6.6 --verbose --file=dist/coverage/**/*.xml : echo 'overrode the default tag'"
+     "${docker_run_cmd} ${DEFAULT_IMAGE}:v6.6.6 --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir : echo 'overrode the default tag'"
 
   run $PWD/hooks/post-command
 
@@ -93,7 +93,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_TAG=v1.2.3
 
   stub docker \
-     "${docker_run_cmd} testing/codecov:v1.2.3 --verbose --file=blah.xml : echo 'overrode everything'"
+     "${docker_run_cmd} testing/codecov:v1.2.3 --verbose --file=blah.xml --rootDir=/workdir : echo 'overrode everything'"
 
   run $PWD/hooks/post-command
 


### PR DESCRIPTION
Before adding the `--rootDir` option to our invocations in #26, we
were silently failing to upload code coverage statistics to Codecov
for two weeks.

By default, `codecov` always returns an exit code of `0`, whether it
succeeded or failed, specifically to _not_ impact CI jobs. However,
this also can make it difficult to see when reporting of statistics
has failed!

The `codecov` uploader _does_ have a `--nonZero` flag, however, which
will enable failures to return a non-zero exit code, should you
desire.

Here, we add a new `fail_job_on_error` parameter which governs whether
or not a failure of this plugin will fail the Buildkite job it is part
of. If the value is `true`, we add the `--nonZero` option; if not, we
don't.

We will default to `true` for the time being.

If this turns out to be problematic, it can be easily counteracted
globally in a given pipeline by adding the following to the top
of the pipeline definition:

```yaml
env:
  BUILDKITE_PLUGIN_CODECOV_FAIL_JOB_ON_ERROR: false
```

A potential improvement to be made later could be to add retries to
lessen the impact of any transient network issues.

(A few additional minor tweaks to tests and documentation were 
added in separate commits, as well.)

Signed-off-by: Christopher Maier <chris@graplsecurity.com>