### PR TITLE
Add a --user= to docker run, to enable codecov on files that are rwx------

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -17,6 +17,10 @@ readonly file_glob="${BUILDKITE_PLUGIN_CODECOV_FILE:-${default_file}}"
 
 readonly default_fail_job_on_error="true"
 
+# (--user, --group - but busybox doesn't support the long-form)
+docker_user="$(id -u):$(id -g)"
+readonly docker_user
+
 codecov_args=(--verbose --file="${file_glob}" --rootDir=/workdir)
 
 if [ "${BUILDKITE_PLUGIN_CODECOV_FAIL_JOB_ON_ERROR:-${default_fail_job_on_error}}" = "true" ]; then
@@ -29,6 +33,7 @@ docker run \
     --interactive \
     --tty \
     --rm \
+    --user="${docker_user}" \
     --label="com.buildkite.job-id=${BUILDKITE_JOB_ID}" \
     --mount=type=bind,source="$(pwd)",destination=/workdir,readonly \
     --workdir=/workdir \

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -11,13 +11,15 @@ setup() {
 
     export DEFAULT_IMAGE="docker.cloudsmith.io/grapl/releases/codecov"
     export DEFAULT_TAG="latest"
+    docker_user="$(id -u):$(id -g)"
+    readonly docker_user
 
     # This is the default docker run command that we use, up to the
     # point where we specify the specific container to use, and the
     # arguments to it. This much of the command is constant, so we're
     # just defining it up front to make stubbing out `docker` less
     # verbose.
-    export docker_run_cmd="run --init --interactive --tty --rm --label=\"com.buildkite.job-id=${BUILDKITE_JOB_ID}\" --mount=type=bind,source=\"$(pwd)\",destination=/workdir,readonly --workdir=/workdir --env=CODECOV_TOKEN --env=BUILDKITE --env=BUILDKITE_BRANCH --env=BUILDKITE_BUILD_NUMBER --env=BUILDKITE_BUILD_URL --env=BUILDKITE_COMMIT --env=BUILDKITE_JOB_ID --env=BUILDKITE_PROJECT_SLUG --"
+    export docker_run_cmd="run --init --interactive --tty --rm --user=${docker_user} --label=\"com.buildkite.job-id=${BUILDKITE_JOB_ID}\" --mount=type=bind,source=\"$(pwd)\",destination=/workdir,readonly --workdir=/workdir --env=CODECOV_TOKEN --env=BUILDKITE --env=BUILDKITE_BRANCH --env=BUILDKITE_BUILD_NUMBER --env=BUILDKITE_BUILD_URL --env=BUILDKITE_COMMIT --env=BUILDKITE_JOB_ID --env=BUILDKITE_PROJECT_SLUG --"
 }
 
 teardown() {


### PR DESCRIPTION
https://github.com/grapl-security/issue-tracker/issues/886

This is a solution to a *theory* - that previously codecov was having trouble reading some stuff in the grapl root because it was:
- running under Docker
- as a different user
- trying to read files that were owned and only readable by $(whoami)

I'm not entirely positive this is what's happening in prod but it's a compelling-enough theory.