### PR TITLE
Update chronotc/monorepo-diff Buildkite Plugin to v2.2.0

### DIFF
--- a/.buildkite/pipeline.merge.yml
+++ b/.buildkite/pipeline.merge.yml
@@ -7,7 +7,7 @@ steps:
   - label: ":thinking_face: Build Codecov Container?"
     plugins:
       - grapl-security/grapl-release#v0.1.1
-      - chronotc/monorepo-diff#v2.0.4:
+      - chronotc/monorepo-diff#v2.2.0:
           diff: grapl_diff.sh
           log_level: "debug"
           watch:


### PR DESCRIPTION
Update chronotc/monorepo-diff Buildkite plugin version to v2.2.0

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖