### PR TITLE
Add `flags` configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ the [Codecov Uploader][uploader].
 
 Defaults to `dist/coverage/**/*.xml`.
 
+### `flags` (optional, string)
+
+Flag the upload to group coverage metrics.
+The value is passed as the `--flags` [argument](https://docs.codecov.com/docs/flags) to
+the [Codecov Uploader][uploader].
+
 ### `image` (optional, string)
 
 The container image with the Codecov Uploader binary that the plugin

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -27,6 +27,10 @@ if [ "${BUILDKITE_PLUGIN_CODECOV_FAIL_JOB_ON_ERROR:-${default_fail_job_on_error}
     codecov_args+=(--nonZero)
 fi
 
+if [[ -v BUILDKITE_PLUGIN_CODECOV_FLAGS ]]; then
+    codecov_args+=(--flags="${BUILDKITE_PLUGIN_CODECOV_FLAGS}")
+fi
+
 echo "--- :codecov: Uploading Coverage Reports"
 docker run \
     --init \

--- a/plugin.yml
+++ b/plugin.yml
@@ -9,6 +9,11 @@ configuration:
       description: |
         The file(s) to upload; defaults to `dist/coverage/**/*.xml`.
       type: string
+    flags:
+      description: |
+        Flag the uploaded report in order to group it based on
+        type of tests or sub-projects/teams
+      type: string
     image:
       description: |
         The `codecov` image to use; defaults to

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -26,6 +26,7 @@ teardown() {
     unset BUILDKITE_COMMAND_EXIT_STATUS
 
     unset BUILDKITE_PLUGIN_CODECOV_FILE
+    unset BUILDKITE_PLUGIN_CODECOV_FLAGS
     unset BUILDKITE_PLUGIN_CODECOV_IMAGE
     unset BUILDKITE_PLUGIN_CODECOV_IMAGE_TAG
     unset BUILDKITE_PLUGIN_CODECOV_FAIL_JOB_ON_ERROR
@@ -60,6 +61,19 @@ teardown() {
   run $PWD/hooks/post-command
 
   assert_output --partial "overriding default file glob"
+  assert_success
+  unstub docker
+}
+
+@test "can set flags" {
+  export BUILDKITE_PLUGIN_CODECOV_FLAGS="test-flags"
+
+  stub docker \
+       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero --flags=test-flags : echo 'setting flags'"
+
+  run $PWD/hooks/post-command
+
+  assert_output --partial "setting flags"
   assert_success
   unstub docker
 }


### PR DESCRIPTION
Thanks for this plugin - I've been keen to step away from the Bash based uploader, for a while now.

This PR adds a `flags` configuration parameter, which will be passed as the `--flags` option to the uploader.

(We require it to upload different coverage reports from a monorepo)