### PR TITLE
Add `always_pull` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,11 @@ steps:
 ```
 
 ## Configuration
-All configuration values are listed in alphabetical order for ease of use.
+Configuration flags are organized by thematic category.
 
-### `fail_job_on_error` (optional, boolean)
+### `codecov` Uploader Flags
 
-Whether or not an error in Codecov will fail the job. This can be
-useful for catching misconfigurations and errors in your Codecov
-setup, at the expense of failing jobs that would otherwise succeed.
-
-Defaults to `true`.
-
-### `file` (optional, string)
+#### `file` (optional, string)
 
 A file name or glob for the coverage files to upload to
 https://coverage.io. The value is passed as the `--file` argument to
@@ -97,13 +91,25 @@ the [Codecov Uploader][uploader].
 
 Defaults to `dist/coverage/**/*.xml`.
 
-### `flags` (optional, string)
+#### `flags` (optional, string)
 
-Flag the upload to group coverage metrics.
-The value is passed as the `--flags` [argument](https://docs.codecov.com/docs/flags) to
-the [Codecov Uploader][uploader].
+Flag the upload to group coverage metrics. The value is passed as the
+`--flags` [argument](https://docs.codecov.com/docs/flags) to the
+[Codecov Uploader][uploader].
 
-### `image` (optional, string)
+### Error Handling
+
+#### `fail_job_on_error` (optional, boolean)
+
+Whether or not an error in Codecov will fail the job. This can be
+useful for catching misconfigurations and errors in your Codecov
+setup, at the expense of failing jobs that would otherwise succeed.
+
+Defaults to `true`.
+
+### Container Image Configuration
+
+#### `image` (optional, string)
 
 The container image with the Codecov Uploader binary that the plugin
 uses. Any container used should have the `codecov` binary as its
@@ -111,7 +117,7 @@ entrypoint.
 
 Defaults to `docker.cloudsmith.io/grapl/releases/codecov`.
 
-### `tag` (optional, string)
+#### `tag` (optional, string)
 
 The container image tag the plugin uses.
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ steps:
 This can also be set this globally using the
 `BUILDKITE_PLUGIN_CODECOV_TAG` environment variable.
 
+If using the `latest` tag of the image, it can be useful to explicitly
+pull the image before running. Since the `latest` tag will change over
+time, this ensures that you always get the _actual_ latest
+image. While this is generally not a problem if you are using
+short-lived or single-use agents, longer-lived agents would continue
+to use whatever image was tagged `latest` when they ran their first
+`codecov` upload.
+
+To explicitly pull the image, set `always_pull` to `true`.
+
+```yml
+steps:
+  - command: make test
+    plugins:
+      - grapl-security/codecov#v0.1.5:
+          image: foobar/codecov
+          tag: latest
+          always_pull: true
+```
+
 By default, this plugin will fail a job if Codecov does not
 succesfully run. If you do not want to do this, use the
 `fail_job_on_error` parameter:
@@ -122,6 +142,14 @@ Defaults to `docker.cloudsmith.io/grapl/releases/codecov`.
 The container image tag the plugin uses.
 
 Defaults to `latest`.
+
+#### `always_pull` (optional, boolean)
+
+Whether or not to perform an explicit `docker pull` of the configured
+image before running. Useful when using the `latest` tag to ensure you
+are always using the _actual_ latest image.
+
+Defaults to `false`.
 
 ## Building and Contributing
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -2,34 +2,50 @@
 
 set -euo pipefail
 
-if [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -ne 0 ]; then
+if [[ "${BUILDKITE_COMMAND_EXIT_STATUS}" -ne 0 ]]; then
     echo "--- :codecov: Skipping upload because job failed"
     exit 0
 fi
 
+# Accumulate all the arguments to pass to the `codecov` binary; we'll
+# always use `--verbose` to make debugging problems easier.
+codecov_args=(--verbose)
+
+# Resolve file glob
+########################################################################
 # This is Grapl's default coverage location and format
 readonly default_file="dist/coverage/**/*.xml"
+readonly file="${BUILDKITE_PLUGIN_CODECOV_FILE:-${default_file}}"
+codecov_args+=(--file="${file}")
+
+# Resolve flags
+########################################################################
+if [[ -v BUILDKITE_PLUGIN_CODECOV_FLAGS ]]; then
+    codecov_args+=(--flags="${BUILDKITE_PLUGIN_CODECOV_FLAGS}")
+fi
+
+# Resolve fail-on-error behavior
+########################################################################
+readonly default_fail_job_on_error="true"
+if [[ "${BUILDKITE_PLUGIN_CODECOV_FAIL_JOB_ON_ERROR:-${default_fail_job_on_error}}" =~ ^(true|on|1)$ ]]; then
+    codecov_args+=(--nonZero)
+fi
+
+# Resolve container image details
+########################################################################
 readonly default_image="docker.cloudsmith.io/grapl/releases/codecov"
 readonly default_tag="latest"
-
 readonly image="${BUILDKITE_PLUGIN_CODECOV_IMAGE:-${default_image}}:${BUILDKITE_PLUGIN_CODECOV_TAG:-${default_tag}}"
-readonly file_glob="${BUILDKITE_PLUGIN_CODECOV_FILE:-${default_file}}"
 
-readonly default_fail_job_on_error="true"
+########################################################################
+
+# We'll mount the current directory at this path in the container
+readonly workdir="/workdir"
+codecov_args+=(--rootDir="${workdir}")
 
 # (--user, --group - but busybox doesn't support the long-form)
 docker_user="$(id -u):$(id -g)"
 readonly docker_user
-
-codecov_args=(--verbose --file="${file_glob}" --rootDir=/workdir)
-
-if [ "${BUILDKITE_PLUGIN_CODECOV_FAIL_JOB_ON_ERROR:-${default_fail_job_on_error}}" = "true" ]; then
-    codecov_args+=(--nonZero)
-fi
-
-if [[ -v BUILDKITE_PLUGIN_CODECOV_FLAGS ]]; then
-    codecov_args+=(--flags="${BUILDKITE_PLUGIN_CODECOV_FLAGS}")
-fi
 
 echo "--- :codecov: Uploading Coverage Reports"
 docker run \
@@ -39,8 +55,8 @@ docker run \
     --rm \
     --user="${docker_user}" \
     --label="com.buildkite.job-id=${BUILDKITE_JOB_ID}" \
-    --mount=type=bind,source="$(pwd)",destination=/workdir,readonly \
-    --workdir=/workdir \
+    --mount=type=bind,source="$(pwd)",destination="${workdir}",readonly \
+    --workdir="${workdir}" \
     --env=CODECOV_TOKEN \
     --env=BUILDKITE \
     --env=BUILDKITE_BRANCH \

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -37,6 +37,12 @@ readonly default_image="docker.cloudsmith.io/grapl/releases/codecov"
 readonly default_tag="latest"
 readonly image="${BUILDKITE_PLUGIN_CODECOV_IMAGE:-${default_image}}:${BUILDKITE_PLUGIN_CODECOV_TAG:-${default_tag}}"
 
+readonly default_always_pull="false"
+if [[ "${BUILDKITE_PLUGIN_CODECOV_ALWAYS_PULL:-${default_always_pull}}" =~ ^(true|on|1)$ ]]; then
+    echo "--- :docker: Explicitly pulling '${image}' image"
+    docker pull "${image}"
+fi
+
 ########################################################################
 
 # We'll mount the current directory at this path in the container

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,6 +5,13 @@ author: https://github.com/grapl-security
 requirements: ["docker"]
 configuration:
   properties:
+    always_pull:
+      description: |
+        Always pull the configured codecov container image. Useful if
+        using the `latest` tag.
+
+        Defaults to `false`.
+      type: boolean
     fail_job_on_error:
       description: |
         Whether or not an error in Codecov will fail the job. This can

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -43,11 +43,11 @@ teardown() {
 
 @test "calls codecov with default values" {
   stub docker \
-       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'uploading default files'"
+       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'STUB - uploading default files'"
 
   run $PWD/hooks/post-command
 
-  assert_output --partial "uploading default files"
+  assert_output --partial "STUB - uploading default files"
   assert_success
   unstub docker
 }
@@ -56,11 +56,11 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_FILE="foo/bar.xml"
 
   stub docker \
-       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=foo/bar.xml --rootDir=/workdir --nonZero : echo 'overriding default file glob'"
+       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=foo/bar.xml --rootDir=/workdir --nonZero : echo 'STUB - overriding default file glob'"
 
   run $PWD/hooks/post-command
 
-  assert_output --partial "overriding default file glob"
+  assert_output --partial "STUB - overriding default file glob"
   assert_success
   unstub docker
 }
@@ -69,11 +69,11 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_FLAGS="test-flags"
 
   stub docker \
-       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero --flags=test-flags : echo 'setting flags'"
+       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero --flags=test-flags : echo 'STUB - setting flags'"
 
   run $PWD/hooks/post-command
 
-  assert_output --partial "setting flags"
+  assert_output --partial "STUB - setting flags"
   assert_success
   unstub docker
 }
@@ -82,11 +82,11 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_IMAGE=foo/codecov
 
   stub docker \
-     "${docker_run_cmd} foo/codecov:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'overrode the default image'"
+     "${docker_run_cmd} foo/codecov:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'STUB - overrode the default image'"
 
   run $PWD/hooks/post-command
 
-  assert_output --partial "overrode the default image"
+  assert_output --partial "STUB - overrode the default image"
   assert_success
   unstub docker
 }
@@ -95,11 +95,11 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_TAG=v6.6.6
 
   stub docker \
-     "${docker_run_cmd} ${DEFAULT_IMAGE}:v6.6.6 --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'overrode the default tag'"
+     "${docker_run_cmd} ${DEFAULT_IMAGE}:v6.6.6 --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'STUB - overrode the default tag'"
 
   run $PWD/hooks/post-command
 
-  assert_output --partial "overrode the default tag"
+  assert_output --partial "STUB - overrode the default tag"
   assert_success
   unstub docker
 }
@@ -110,11 +110,11 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_TAG=v1.2.3
 
   stub docker \
-     "${docker_run_cmd} testing/codecov:v1.2.3 --verbose --file=blah.xml --rootDir=/workdir --nonZero : echo 'overrode everything'"
+     "${docker_run_cmd} testing/codecov:v1.2.3 --verbose --file=blah.xml --rootDir=/workdir --nonZero : echo 'STUB - overrode everything'"
 
   run $PWD/hooks/post-command
 
-  assert_output --partial "overrode everything"
+  assert_output --partial "STUB - overrode everything"
   assert_success
   unstub docker
 }
@@ -123,11 +123,11 @@ teardown() {
     unset BUILDKITE_PLUGIN_CODECOV_FAIL_JOB_ON_ERROR
 
     stub docker \
-         "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'failed, and exit with 1'; exit 1"
+         "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'STUB - failed, and exit with 1'; exit 1"
 
     run $PWD/hooks/post-command
 
-    assert_output --partial "failed, and exit with 1"
+    assert_output --partial "STUB - failed, and exit with 1"
     assert_failure
     unstub docker
 }
@@ -136,11 +136,11 @@ teardown() {
     export BUILDKITE_PLUGIN_CODECOV_FAIL_JOB_ON_ERROR=false
 
     stub docker \
-         "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir : echo 'failed, but exit with 0'; exit 0"
+         "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir : echo 'STUB - failed, but exit with 0'; exit 0"
 
     run $PWD/hooks/post-command
 
-    assert_output --partial "failed, but exit with 0"
+    assert_output --partial "STUB - failed, but exit with 0"
     assert_success
     unstub docker
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -43,7 +43,7 @@ teardown() {
 
 @test "calls codecov with default values" {
   stub docker \
-       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'STUB - uploading default files'"
+       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --nonZero --rootDir=/workdir : echo 'STUB - uploading default files'"
 
   run $PWD/hooks/post-command
 
@@ -56,7 +56,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_FILE="foo/bar.xml"
 
   stub docker \
-       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=foo/bar.xml --rootDir=/workdir --nonZero : echo 'STUB - overriding default file glob'"
+       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=foo/bar.xml --nonZero --rootDir=/workdir : echo 'STUB - overriding default file glob'"
 
   run $PWD/hooks/post-command
 
@@ -69,7 +69,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_FLAGS="test-flags"
 
   stub docker \
-       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero --flags=test-flags : echo 'STUB - setting flags'"
+       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --flags=test-flags --nonZero --rootDir=/workdir : echo 'STUB - setting flags'"
 
   run $PWD/hooks/post-command
 
@@ -82,7 +82,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_IMAGE=foo/codecov
 
   stub docker \
-     "${docker_run_cmd} foo/codecov:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'STUB - overrode the default image'"
+     "${docker_run_cmd} foo/codecov:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --nonZero  --rootDir=/workdir : echo 'STUB - overrode the default image'"
 
   run $PWD/hooks/post-command
 
@@ -95,7 +95,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_TAG=v6.6.6
 
   stub docker \
-     "${docker_run_cmd} ${DEFAULT_IMAGE}:v6.6.6 --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'STUB - overrode the default tag'"
+     "${docker_run_cmd} ${DEFAULT_IMAGE}:v6.6.6 --verbose --file=dist/coverage/**/*.xml --nonZero --rootDir=/workdir : echo 'STUB - overrode the default tag'"
 
   run $PWD/hooks/post-command
 
@@ -110,7 +110,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_TAG=v1.2.3
 
   stub docker \
-     "${docker_run_cmd} testing/codecov:v1.2.3 --verbose --file=blah.xml --rootDir=/workdir --nonZero : echo 'STUB - overrode everything'"
+     "${docker_run_cmd} testing/codecov:v1.2.3 --verbose --file=blah.xml --nonZero --rootDir=/workdir : echo 'STUB - overrode everything'"
 
   run $PWD/hooks/post-command
 
@@ -123,7 +123,7 @@ teardown() {
     unset BUILDKITE_PLUGIN_CODECOV_FAIL_JOB_ON_ERROR
 
     stub docker \
-         "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'STUB - failed, and exit with 1'; exit 1"
+         "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --nonZero --rootDir=/workdir : echo 'STUB - failed, and exit with 1'; exit 1"
 
     run $PWD/hooks/post-command
 

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -25,6 +25,7 @@ setup() {
 teardown() {
     unset BUILDKITE_COMMAND_EXIT_STATUS
 
+    unset BUILDKITE_PLUGIN_CODECOV_ALWAYS_PULL
     unset BUILDKITE_PLUGIN_CODECOV_FILE
     unset BUILDKITE_PLUGIN_CODECOV_FLAGS
     unset BUILDKITE_PLUGIN_CODECOV_IMAGE
@@ -141,6 +142,21 @@ teardown() {
     run $PWD/hooks/post-command
 
     assert_output --partial "STUB - failed, but exit with 0"
+    assert_success
+    unstub docker
+}
+
+@test "pull image" {
+    export BUILDKITE_PLUGIN_CODECOV_ALWAYS_PULL=true
+
+    stub docker \
+         "pull ${DEFAULT_IMAGE}:${DEFAULT_TAG} : echo 'STUB - pulling image'" \
+         "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --nonZero --rootDir=/workdir : echo 'STUB - running codecov'"
+
+    run $PWD/hooks/post-command
+
+    assert_output --partial "STUB - pulling image"
+    assert_output --partial "STUB - running codecov"
     assert_success
     unstub docker
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -43,7 +43,7 @@ teardown() {
 
 @test "calls codecov with default values" {
   stub docker \
-       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir : echo 'uploading default files'"
+       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'uploading default files'"
 
   run $PWD/hooks/post-command
 
@@ -56,7 +56,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_FILE="foo/bar.xml"
 
   stub docker \
-       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=foo/bar.xml --rootDir=/workdir : echo 'overriding default file glob'"
+       "${docker_run_cmd} ${DEFAULT_IMAGE}:${DEFAULT_TAG} --verbose --file=foo/bar.xml --rootDir=/workdir --nonZero : echo 'overriding default file glob'"
 
   run $PWD/hooks/post-command
 
@@ -82,7 +82,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_IMAGE=foo/codecov
 
   stub docker \
-     "${docker_run_cmd} foo/codecov:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir : echo 'overrode the default image'"
+     "${docker_run_cmd} foo/codecov:${DEFAULT_TAG} --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'overrode the default image'"
 
   run $PWD/hooks/post-command
 
@@ -95,7 +95,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_TAG=v6.6.6
 
   stub docker \
-     "${docker_run_cmd} ${DEFAULT_IMAGE}:v6.6.6 --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir : echo 'overrode the default tag'"
+     "${docker_run_cmd} ${DEFAULT_IMAGE}:v6.6.6 --verbose --file=dist/coverage/**/*.xml --rootDir=/workdir --nonZero : echo 'overrode the default tag'"
 
   run $PWD/hooks/post-command
 
@@ -110,7 +110,7 @@ teardown() {
   export BUILDKITE_PLUGIN_CODECOV_TAG=v1.2.3
 
   stub docker \
-     "${docker_run_cmd} testing/codecov:v1.2.3 --verbose --file=blah.xml --rootDir=/workdir : echo 'overrode everything'"
+     "${docker_run_cmd} testing/codecov:v1.2.3 --verbose --file=blah.xml --rootDir=/workdir --nonZero : echo 'overrode everything'"
 
   run $PWD/hooks/post-command
 


### PR DESCRIPTION
If using the `latest` image, you may wish to always pull to ensure you are actually using the latest `latest` image, since this tag will change.

Several other cleanups and refactorings were done in the course of this work; read the individual commits for further details.