### PR TITLE
Update `vault-login` Buildkite plugin to `v0.1.3`

### DIFF
--- a/.buildkite/pipeline.merge.build-container.yml
+++ b/.buildkite/pipeline.merge.build-container.yml
@@ -9,7 +9,7 @@ steps:
     command:
       - make image-push
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - CLOUDSMITH_API_KEY
@@ -27,7 +27,7 @@ steps:
 
   - label: ":cloudsmith::buildkite: Promote new codecov image"
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - CLOUDSMITH_API_KEY

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -11,7 +11,7 @@ steps:
     command:
       - make lint-shell
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - codecov-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN


### PR DESCRIPTION
Update grapl-security/vault-login Buildkite plugin version to v0.1.3

Picks up additional logging features, specifically https://github.com/grapl-security/vault-login-buildkite-plugin/pull/26

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖