### PR TITLE
Update base build image to `ubuntu:22.04`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04 AS base
+FROM ubuntu:22.04 AS base
 
 # The version of the Codecov Uploader to download from
 # https://uploader.codecov.io
@@ -6,8 +6,8 @@ ARG CODECOV_VERSION
 
 RUN apt-get update && \
     apt-get install --yes \
-    curl=7.74.0-1ubuntu2.3 \
-    gpg=2.2.20-1ubuntu3
+    curl=7.81.0-1ubuntu1.3 \
+    gpg=2.2.27-3ubuntu2.1
 
 WORKDIR /workdir
 


### PR DESCRIPTION
Here, we update our base image to `ubuntu:22.04` ("Jammy Jellyfish"
LTS). The previous Ubuntu version we were using, 21.04 ("Hirsute
Hippo") was end-of-lifed on January 20, 2022, and the apt repository
links for it apparently just went dead over the weekend.

The final image we ship continues to be based on a `distroless` image,
but we still have to download and verify the `codecov` binary, so this
ensures our "build environment" continues to work.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
