### PR TITLE
Update Codecov Uploader to v0.3.2

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,13 +5,7 @@ variable "CODECOV_VERSION" {
   #
   # See https://uploader.codecov.io/linux/latest for the current
   # version.
-  #
-  # Update this frequently, as the Uploader is under active
-  # development.
-  #
-  # Alternatively, supply a value for `$CODECOV_VERSION` in the
-  # environment when calling `docker buildx bake`.
-  default = "v0.2.5"
+  default = "v0.3.2"
 }
 
 group "default" {


### PR DESCRIPTION
Just keeping up with the latest.

https://github.com/codecov/uploader/releases/tag/v0.3.2

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
