### PR TITLE
Update `vault-env` Buildkite plugin to `v0.2.0`

### DIFF
--- a/.buildkite/pipeline.merge.build-container.yml
+++ b/.buildkite/pipeline.merge.build-container.yml
@@ -10,7 +10,7 @@ steps:
       - make image-push
     plugins:
       - grapl-security/vault-login#v0.1.3
-      - grapl-security/vault-env#v0.1.0:
+      - grapl-security/vault-env#v0.2.0:
           secrets:
             - CLOUDSMITH_API_KEY
       - docker-login#v2.0.1:
@@ -28,7 +28,7 @@ steps:
   - label: ":cloudsmith::buildkite: Promote new codecov image"
     plugins:
       - grapl-security/vault-login#v0.1.3
-      - grapl-security/vault-env#v0.1.0:
+      - grapl-security/vault-env#v0.2.0:
           secrets:
             - CLOUDSMITH_API_KEY
       - grapl-security/cloudsmith#v0.1.4:

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -12,7 +12,7 @@ steps:
       - make lint-shell
     plugins:
       - grapl-security/vault-login#v0.1.3
-      - grapl-security/vault-env#v0.1.0:
+      - grapl-security/vault-env#v0.2.0:
           secrets:
             - codecov-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 


### PR DESCRIPTION
Update grapl-security/vault-env Buildkite plugin version to v0.2.0

https://github.com/grapl-security/vault-env-buildkite-plugin/releases/tag/v0.2.0

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖